### PR TITLE
premasagar -> anders94

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The client supports both public (unauthenticated) and private (authenticated) ca
 
 For private calls, the user secret is never exposed to other parts of the program or over the Web. The user key is sent as a header to the API, along with a signed request.
 
-Repo home: [github.com/premasagar/poloniex.js][repo]
+Repo home: [github.com/anders94/poloniex.js][repo]
 
 
 ## License
@@ -22,7 +22,7 @@ MIT, open source. See LICENSE file.
 ## Or clone from GitHub
 
 
-    git clone https://github.com/premasagar/poloniex.js.git
+    git clone https://github.com/anders94/poloniex.js.git
     cd poloniex
     npm install
 
@@ -882,8 +882,8 @@ Example response:
     }
 
 
-[repo]: https://github.com/premasagar/poloniex.js
-[repo-zip]: https://github.com/premasagar/poloniex.js/archive/master.zip
+[repo]: https://github.com/anders94/poloniex.js
+[repo-zip]: https://github.com/anders94/poloniex.js/archive/master.zip
 [poloniex]: https://poloniex.com
 [poloniex-api]: https://poloniex.com/api
 [poloniex-keys]: https://poloniex.com/apiKeys

--- a/README.md
+++ b/README.md
@@ -881,6 +881,11 @@ Example response:
       "message": 0
     }
 
+## Changelog
+
+2019-01-08 Migrate from original module author, https://github.com/premasagar/poloniex.js
+2019-01-07 Promises support
+2014-03-31 Initial commit by @premasagar
 
 [repo]: https://github.com/anders94/poloniex.js
 [repo-zip]: https://github.com/anders94/poloniex.js/archive/master.zip

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "poloniex.js",
   "version": "1.0.0",
   "description": "Poloniex API client",
-  "author": "Premasagar Rose <p@premasagar.com>",
+  "author": "Anders Brownworth anders-git@anders.com>",
   "license": "MIT",
   "readmeFilename": "README.md",
   "main": "lib/poloniex",
@@ -14,7 +14,7 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "https://github.com/premasagar/poloniex.js.git"
+    "url": "https://github.com/anders94/poloniex.js.git"
   },
   "keywords": [
     "poloniex",
@@ -24,7 +24,7 @@
     "altcoins"
   ],
   "bugs": {
-    "url": "https://github.com/premasagar/poloniex.js/issues"
+    "url": "https://github.com/anders94/poloniex.js/issues"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
This is the first in a two step process to migrate from premasagar, the module's original author, to the official Poloniex GitHub account. I am making this pit-stop in my personal account as permissions get ironed out on the Poloniex account. I hope to complete this migration within the next day.

This change (and the module's movements) should not incur issues for people using the module.